### PR TITLE
WIP: allow Provisioners to keep retrying Provision after PVC deleted

### DIFF
--- a/controller/volume.go
+++ b/controller/volume.go
@@ -38,6 +38,11 @@ type Provisioner interface {
 	Delete(*v1.PersistentVolume) error
 }
 
+// RetryProvisioner is like Provisioner but...
+type RetryProvisioner interface {
+	RetryProvision(VolumeOptions) (*v1.PersistentVolume, error, bool)
+}
+
 // Qualifier is an optional interface implemented by provisioners to determine
 // whether a claim should be provisioned as early as possible (e.g. prior to
 // leader election).


### PR DESCRIPTION
WIP...`claimsToRetry sync.Map` contains not only PVCs that have been deleted and need provisioning, but all PVCs that need provisioning.

So PVCs that have been deleted would be some subset of `claimsToRetry`. Not sure yet how to clean them up when provision succeeds.

/assign @jsafrane