### PR TITLE
Support dynamic provisioning for CSI migration scenarios

### DIFF
--- a/.Gopkg.toml
+++ b/.Gopkg.toml
@@ -53,6 +53,10 @@
   branch = "master"
   name = "k8s.io/client-go"
 
+[[constraint]]
+  branch = "master"
+  name = "k8s.io/csi-translation-lib"
+
 [prune]
   go-tests = true
   unused-packages = true


### PR DESCRIPTION
Part of enhancements for [kubernetes/enhancements#625](https://github.com/kubernetes/enhancements/issues/625)

This PR depends on https://github.com/kubernetes/kubernetes/pull/73653 for a set of changes needed in in-tree PV Controller to call out to the external provisioning controller for in-tree plugins if they are migratable to CSI. The basic steps in that PR are:

1. Check if in-tree plugin is migratable to CSI. If so:
2. Set `annStorageProvisioner` in the PVC to CSI plugin name that superseded the specified in-tree plugin.
3. Do not proceed with in-tree provisioning and return so that external provisioner can act on the claim.

This PR introduces the following changes in lib-external-provisioner in the context of dynamic provisioning in CSI migration scenarios to act on the above annotated claims:

1. Enhances `getStorageClassFields` to check (through `GetCSINameFromIntreeName`) if the storageclass provisioner has a corresponding CSI plugin that supersedes it. If so:
2. Makes `getStorageClassFields` aware that it's handling dynamic volume provisioning for an in-tree plugin that has been migrated to CSI because [a] For regular in-tree provisioning path, external provisioning will never get invoked [b] For regular CSI provisioning path, `GetCSINameFromIntreeName` would not return anything for a CSI plugin name.
3. Enhances `getStorageClassFields` to [a] translate in-tree storage class parameters to the corresponding CSI plugin parameters using `TranslateInTreeStorageClassParametersToCSI` [b] return the CSI plugin name (instead of the storage class in-tree provisioner) as the provisioner name (so that it aligns with `ctrl.provisionerName`) and [c] return a boolean to `provisionClaimOperation` indicating dynamic provisioning in a CSI migration context
4. Enhances `provisionClaimOperation` to invoke `TranslateCSIPVToInTree` for dynamic provisioning in a CSI migration context.
5. A Unit test to ensure a storage class with in-tree provisioner can delegate to external provisioner for provisioning and translate the PV back to in-tree source.

/sig storage
/assign @jsafrane @saad-ali
/cc @msau42 @leakingtapan @davidz627