### PR TITLE
BREAKING CHANGE: Refactor volume options to provision options to stop using redundant internal struct fields and ease migration translation

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1236,12 +1236,6 @@ func (ctrl *ProvisionController) provisionClaimOperation(claim *v1.PersistentVol
 		return ProvisioningFinished, nil
 	}
 
-	reclaimPolicy := v1.PersistentVolumeReclaimDelete
-	if ctrl.kubeVersion.AtLeast(utilversion.MustParseSemantic("v1.8.0")) {
-		reclaimPolicy = *class.ReclaimPolicy
-	}
-	mountOptions := class.MountOptions
-
 	var selectedNode *v1.Node
 	if ctrl.kubeVersion.AtLeast(utilversion.MustParseSemantic("v1.11.0")) {
 		// Get SelectedNode
@@ -1255,14 +1249,11 @@ func (ctrl *ProvisionController) provisionClaimOperation(claim *v1.PersistentVol
 		}
 	}
 
-	options := VolumeOptions{
-		PersistentVolumeReclaimPolicy: reclaimPolicy,
-		PVName:                        pvName,
-		PVC:                           claim,
-		MountOptions:                  mountOptions,
-		Parameters:                    class.Parameters,
-		SelectedNode:                  selectedNode,
-		AllowedTopologies:             class.AllowedTopologies,
+	options := ProvisionOptions{
+		StorageClass: class,
+		PVName:       pvName,
+		PVC:          claim,
+		SelectedNode: selectedNode,
 	}
 
 	ctrl.eventRecorder.Event(claim, v1.EventTypeNormal, "Provisioning", fmt.Sprintf("External provisioner is provisioning volume for claim %q", claimToClaimKey(claim)))

--- a/examples/hostpath-provisioner/hostpath-provisioner.go
+++ b/examples/hostpath-provisioner/hostpath-provisioner.go
@@ -61,7 +61,7 @@ func NewHostPathProvisioner() controller.Provisioner {
 var _ controller.Provisioner = &hostPathProvisioner{}
 
 // Provision creates a storage asset and returns a PV object representing it.
-func (p *hostPathProvisioner) Provision(options controller.VolumeOptions) (*v1.PersistentVolume, error) {
+func (p *hostPathProvisioner) Provision(options controller.ProvisionOptions) (*v1.PersistentVolume, error) {
 	path := path.Join(p.pvDir, options.PVName)
 
 	if err := os.MkdirAll(path, 0777); err != nil {
@@ -76,7 +76,7 @@ func (p *hostPathProvisioner) Provision(options controller.VolumeOptions) (*v1.P
 			},
 		},
 		Spec: v1.PersistentVolumeSpec{
-			PersistentVolumeReclaimPolicy: options.PersistentVolumeReclaimPolicy,
+			PersistentVolumeReclaimPolicy: *options.StorageClass.ReclaimPolicy,
 			AccessModes:                   options.PVC.Spec.AccessModes,
 			Capacity: v1.ResourceList{
 				v1.ResourceName(v1.ResourceStorage): options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)],

--- a/gidallocator/gidallocator.go
+++ b/gidallocator/gidallocator.go
@@ -63,11 +63,11 @@ func New(client kubernetes.Interface) Allocator {
 	}
 }
 
-// AllocateNext allocates the next available GID for the given VolumeOptions
+// AllocateNext allocates the next available GID for the given ProvisionOptions
 // (claim's options for a volume it wants) from the appropriate GID table.
-func (a *Allocator) AllocateNext(options controller.VolumeOptions) (int, error) {
+func (a *Allocator) AllocateNext(options controller.ProvisionOptions) (int, error) {
 	class := util.GetPersistentVolumeClaimClass(options.PVC)
-	gidMin, gidMax, err := parseClassParameters(options.Parameters)
+	gidMin, gidMax, err := parseClassParameters(options.StorageClass.Parameters)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
`VolumeOptions` was just copying a lot of fields from storage class. This was both redundant and making translation for migration much harder (as we had to support translating this internal struct). With using StorageClass directly we've simplified the `ProvisionOptions` so when storage class is updated we don't have to make a corresponding change to `VolumeOptions` as well as allowing migration translation to work on a public API object simplifying dependencies.

/assign @jsafrane @msau42 @saad-ali 