### PR TITLE
Change so that provisioners 'shouldDelete' a volume if it is 'migrated-to' the provisioner in question

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -71,6 +71,13 @@ const annClass = "volume.beta.kubernetes.io/storage-class"
 // recognize dynamically provisioned PVs in its decisions).
 const annDynamicallyProvisioned = "pv.kubernetes.io/provisioned-by"
 
+// AnnMigratedTo annotation is added to a PVC that is supposed to be
+// dynamically provisioned/deleted by by its corresponding CSI driver
+// through the CSIMigration feature flags. It allows external provisioners
+// to determine which PVs are considered migrated and safe to operate on for
+// Deletion.
+const annMigratedTo = "volume.beta.kubernetes.io/migrated-to"
+
 const annStorageProvisioner = "volume.beta.kubernetes.io/storage-provisioner"
 
 // This annotation is added to a PVC that has been triggered by scheduler to
@@ -1140,7 +1147,9 @@ func (ctrl *ProvisionController) shouldDelete(volume *v1.PersistentVolume) bool 
 		return false
 	}
 
-	if ann := volume.Annotations[annDynamicallyProvisioned]; ann != ctrl.provisionerName {
+	ann := volume.Annotations[annDynamicallyProvisioned]
+	migratedTo := volume.Annotations[annMigratedTo]
+	if ann != ctrl.provisionerName && migratedTo != ctrl.provisionerName {
 		return false
 	}
 

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -787,6 +787,30 @@ func TestShouldDelete(t *testing.T) {
 			serverGitVersion: "v1.9.0",
 			expectedShould:   true,
 		},
+		{
+			name:            "migrated to",
+			provisionerName: "csi.driver",
+			volume: newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete,
+				map[string]string{annDynamicallyProvisioned: "foo.bar/baz", annMigratedTo: "csi.driver"}),
+			serverGitVersion: "v1.17.0",
+			expectedShould:   true,
+		},
+		{
+			name:            "migrated to random",
+			provisionerName: "csi.driver",
+			volume: newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete,
+				map[string]string{annDynamicallyProvisioned: "foo.bar/baz", annMigratedTo: "some.foo.driver"}),
+			serverGitVersion: "v1.17.0",
+			expectedShould:   false,
+		},
+		{
+			name:            "csidriver but no migrated annotation",
+			provisionerName: "csi.driver",
+			volume: newVolume("volume-1", v1.VolumeReleased, v1.PersistentVolumeReclaimDelete,
+				map[string]string{annDynamicallyProvisioned: "foo.bar/baz"}),
+			serverGitVersion: "v1.17.0",
+			expectedShould:   false,
+		},
 	}
 	for _, test := range tests {
 		client := fake.NewSimpleClientset()


### PR DESCRIPTION
/assign @msau42 @jsafrane 

Part of fix for: https://github.com/kubernetes/kubernetes/issues/79043