### PR TITLE
Remove Brad Childs from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,8 +3,6 @@
 approvers:
 - wongma7
 - jsafrane
-- childsb
 reviewers:
 - wongma7
 - jsafrane
-- childsb


### PR DESCRIPTION
This PR removes Brad's github ID from the OWNERS files in this repo.

Associated with kubernetes/community#4418