### PR TITLE
dep: lock onto Kubernetes 1.17.2

### DIFF
--- a/.Gopkg.toml
+++ b/.Gopkg.toml
@@ -38,15 +38,15 @@
   name = "golang.org/x/time"
 
 [[constraint]]
-  branch = "master"
+  version = "v0.17.2"
   name = "k8s.io/api"
 
 [[constraint]]
-  branch = "master"
+  version = "v0.17.2"
   name = "k8s.io/apimachinery"
 
 [[constraint]]
-  branch = "master"
+  version = "v0.17.2"
   name = "k8s.io/client-go"
 
 [prune]


### PR DESCRIPTION
Following "master" is dangerous (not reproducible) and currently broken:

```
$ make dep
cp .Gopkg.toml Gopkg.toml
dep init
init aborted: manifest already exists at /nvme/gopath/src/sigs.k8s.io/sig-storage-lib-external-provisioner/Gopkg.toml
make: [Makefile:19: dep] Error 1 (ignored)
dep ensure
Solving failure: No versions of sigs.k8s.io/structured-merge-diff met constraints:
	v2.0.1: Could not introduce sigs.k8s.io/structured-merge-diff@v2.0.1, as its subpackage sigs.k8s.io/structured-merge-diff/v3/value is missing. (Package is required by k8s.io/apimachinery@master.)
	v2.0.0: Could not introduce sigs.k8s.io/structured-merge-diff@v2.0.0, as its subpackage sigs.k8s.io/structured-merge-diff/v3/value is missing. (Package is required by k8s.io/apimachinery@master.)
	v1.0.2: Could not introduce sigs.k8s.io/structured-merge-diff@v1.0.2, as its subpackage sigs.k8s.io/structured-merge-diff/v3/value is missing. (Package is required by k8s.io/apimachinery@master.)
	v1.0.1: Could not introduce sigs.k8s.io/structured-merge-diff@v1.0.1, as its subpackage sigs.k8s.io/structured-merge-diff/v3/value is missing. (Package is required by k8s.io/apimachinery@master.)
	v1.0.0: Could not introduce sigs.k8s.io/structured-merge-diff@v1.0.0, as its subpackage sigs.k8s.io/structured-merge-diff/v3/value is missing. (Package is required by k8s.io/apimachinery@master.)
	master: Could not introduce sigs.k8s.io/structured-merge-diff@master, as its subpackage sigs.k8s.io/structured-merge-diff/v3/value is missing. (Package is required by k8s.io/apimachinery@master.)
	benchmarks: Could not introduce sigs.k8s.io/structured-merge-diff@benchmarks, as its subpackage sigs.k8s.io/structured-merge-diff/v3/value is missing. (Package is required by k8s.io/apimachinery@master.)
	release-1.0: Could not introduce sigs.k8s.io/structured-merge-diff@release-1.0, as its subpackage sigs.k8s.io/structured-merge-diff/v3/value is missing. (Package is required by k8s.io/apimachinery@master.)
	release-2.0: Could not introduce sigs.k8s.io/structured-merge-diff@release-2.0, as its subpackage sigs.k8s.io/structured-merge-diff/v3/value is missing. (Package is required by k8s.io/apimachinery@master.)
make: *** [Makefile:20: dep] Error 1
```