### PR TITLE
controller: enable rescheduling of pods

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1031,6 +1031,7 @@ func (ctrl *ProvisionController) syncClaim(obj interface{}) error {
 
 	should, err := ctrl.shouldProvision(claim)
 	if err != nil {
+		ctrl.updateProvisionStats(claim, err, time.Time{})
 		return err
 	} else if should {
 		startTime := time.Now()

--- a/controller/metrics/metrics.go
+++ b/controller/metrics/metrics.go
@@ -25,61 +25,93 @@ const (
 	ControllerSubsystem = "controller"
 )
 
+// Metrics contains the metrics for a certain subsystem name.
+type Metrics struct {
+	// PersistentVolumeClaimProvisionTotal is used to collect accumulated count of persistent volumes provisioned.
+	PersistentVolumeClaimProvisionTotal *prometheus.CounterVec
+	// PersistentVolumeClaimProvisionFailedTotal is used to collect accumulated count of persistent volume provision failed attempts.
+	PersistentVolumeClaimProvisionFailedTotal *prometheus.CounterVec
+	// PersistentVolumeClaimProvisionDurationSeconds is used to collect latency in seconds to provision persistent volumes.
+	PersistentVolumeClaimProvisionDurationSeconds *prometheus.HistogramVec
+	// PersistentVolumeDeleteTotal is used to collect accumulated count of persistent volumes deleted.
+	PersistentVolumeDeleteTotal *prometheus.CounterVec
+	// PersistentVolumeDeleteFailedTotal is used to collect accumulated count of persistent volume delete failed attempts.
+	PersistentVolumeDeleteFailedTotal *prometheus.CounterVec
+	// PersistentVolumeDeleteDurationSeconds is used to collect latency in seconds to delete persistent volumes.
+	PersistentVolumeDeleteDurationSeconds *prometheus.HistogramVec
+}
+
+// M contains the metrics with ControllerSubsystem as subsystem name.
+var M = New(ControllerSubsystem)
+
+// These variables are defined merely for API compatibility.
 var (
 	// PersistentVolumeClaimProvisionTotal is used to collect accumulated count of persistent volumes provisioned.
-	PersistentVolumeClaimProvisionTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: ControllerSubsystem,
-			Name:      "persistentvolumeclaim_provision_total",
-			Help:      "Total number of persistent volumes provisioned. Broken down by storage class name.",
-		},
-		[]string{"class"},
-	)
+	PersistentVolumeClaimProvisionTotal = M.PersistentVolumeClaimProvisionTotal
 	// PersistentVolumeClaimProvisionFailedTotal is used to collect accumulated count of persistent volume provision failed attempts.
-	PersistentVolumeClaimProvisionFailedTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: ControllerSubsystem,
-			Name:      "persistentvolumeclaim_provision_failed_total",
-			Help:      "Total number of persistent volume provision failed attempts. Broken down by storage class name.",
-		},
-		[]string{"class"},
-	)
+	PersistentVolumeClaimProvisionFailedTotal = M.PersistentVolumeClaimProvisionFailedTotal
 	// PersistentVolumeClaimProvisionDurationSeconds is used to collect latency in seconds to provision persistent volumes.
-	PersistentVolumeClaimProvisionDurationSeconds = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Subsystem: ControllerSubsystem,
-			Name:      "persistentvolumeclaim_provision_duration_seconds",
-			Help:      "Latency in seconds to provision persistent volumes. Broken down by storage class name.",
-			Buckets:   prometheus.DefBuckets,
-		},
-		[]string{"class"},
-	)
+	PersistentVolumeClaimProvisionDurationSeconds = M.PersistentVolumeClaimProvisionDurationSeconds
 	// PersistentVolumeDeleteTotal is used to collect accumulated count of persistent volumes deleted.
-	PersistentVolumeDeleteTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: ControllerSubsystem,
-			Name:      "persistentvolume_delete_total",
-			Help:      "Total number of persistent volumes deleteed. Broken down by storage class name.",
-		},
-		[]string{"class"},
-	)
+	PersistentVolumeDeleteTotal = M.PersistentVolumeDeleteTotal
 	// PersistentVolumeDeleteFailedTotal is used to collect accumulated count of persistent volume delete failed attempts.
-	PersistentVolumeDeleteFailedTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Subsystem: ControllerSubsystem,
-			Name:      "persistentvolume_delete_failed_total",
-			Help:      "Total number of persistent volume delete failed attempts. Broken down by storage class name.",
-		},
-		[]string{"class"},
-	)
+	PersistentVolumeDeleteFailedTotal = M.PersistentVolumeDeleteFailedTotal
 	// PersistentVolumeDeleteDurationSeconds is used to collect latency in seconds to delete persistent volumes.
-	PersistentVolumeDeleteDurationSeconds = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Subsystem: ControllerSubsystem,
-			Name:      "persistentvolume_delete_duration_seconds",
-			Help:      "Latency in seconds to delete persistent volumes. Broken down by storage class name.",
-			Buckets:   prometheus.DefBuckets,
-		},
-		[]string{"class"},
-	)
+	PersistentVolumeDeleteDurationSeconds = M.PersistentVolumeDeleteDurationSeconds
 )
+
+// New creates a new set of metrics with the goven subsystem name.
+func New(subsystem string) Metrics {
+	return Metrics{
+		PersistentVolumeClaimProvisionTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      "persistentvolumeclaim_provision_total",
+				Help:      "Total number of persistent volumes provisioned succesfully. Broken down by storage class name.",
+			},
+			[]string{"class"},
+		),
+		PersistentVolumeClaimProvisionFailedTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      "persistentvolumeclaim_provision_failed_total",
+				Help:      "Total number of persistent volume provision failed attempts. Broken down by storage class name.",
+			},
+			[]string{"class"},
+		),
+		PersistentVolumeClaimProvisionDurationSeconds: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Subsystem: subsystem,
+				Name:      "persistentvolumeclaim_provision_duration_seconds",
+				Help:      "Latency in seconds to provision persistent volumes. Failed provisioning attempts are ignored. Broken down by storage class name.",
+				Buckets:   prometheus.DefBuckets,
+			},
+			[]string{"class"},
+		),
+		PersistentVolumeDeleteTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      "persistentvolume_delete_total",
+				Help:      "Total number of persistent volumes deleted succesfully. Broken down by storage class name.",
+			},
+			[]string{"class"},
+		),
+		PersistentVolumeDeleteFailedTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Subsystem: subsystem,
+				Name:      "persistentvolume_delete_failed_total",
+				Help:      "Total number of persistent volume delete failed attempts. Broken down by storage class name.",
+			},
+			[]string{"class"},
+		),
+		PersistentVolumeDeleteDurationSeconds: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Subsystem: subsystem,
+				Name:      "persistentvolume_delete_duration_seconds",
+				Help:      "Latency in seconds to delete persistent volumes. Failed deletion attempts are ignored. Broken down by storage class name.",
+				Buckets:   prometheus.DefBuckets,
+			},
+			[]string{"class"},
+		),
+	}
+}

--- a/controller/volume.go
+++ b/controller/volume.go
@@ -97,6 +97,13 @@ const (
 	// first ProvisionExt call, ProvisioningFinished is assumed (the provisioning
 	// could not even start).
 	ProvisioningNoChange ProvisioningState = "NoChange"
+	// ProvisioningReschedule tells the controller that it shall stop all further
+	// attempts to provision the volume and instead ask the Kubernetes scheduler
+	// to pick a different node. This only makes sense for volumes with a selected
+	// node, i.e. those with late binding, and must only be returned when it is certain
+	// that provisioning does not continue in the background. The error returned together
+	// with this state contains further information why rescheduling is needed.
+	ProvisioningReschedule ProvisioningState = "Reschedule"
 )
 
 // IgnoredError is the value for Delete to return to indicate that the call has


### PR DESCRIPTION
For dynamic PV provisioning with node, provisioner may fail because node
is wrong. `selectedNode` must be removed to notify scheduler to schedule
again.

Original code by Yecheng. Rebased and extended by Patrick Ohly:

Rescheduling must not be done for operations that are still in
progress (ProvisionInBackground) or that still have a reasonable
chance of succeeding (ProvisioningNoChange). Provisioners really
should implement the ProvisionerExt interface and carefully consider
the result return value when they run into errors.