### PR TITLE
controller: ignore deleted PVs

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1047,7 +1047,7 @@ func (ctrl *ProvisionController) syncVolumeHandler(ctx context.Context, key stri
 		return err
 	}
 	if !exists {
-		utilruntime.HandleError(fmt.Errorf("volume %q in work queue no longer exists", key))
+		// Already deleted, nothing to do anymore.
 		return nil
 	}
 


### PR DESCRIPTION
It is normal that a volume is still in the work queue after it was
deleted, which used to trigger an unnecessary error log message:

```    
    I1008 18:58:53.808993       1 controller.go:1467] delete "pvc-0e8331f7-de7a-4c0c-a678-724e05c3b716": started
    I1008 18:58:54.125842       1 controller.go:1482] delete "pvc-0e8331f7-de7a-4c0c-a678-724e05c3b716": volume deleted
    I1008 18:58:54.159675       1 controller.go:1532] delete "pvc-0e8331f7-de7a-4c0c-a678-724e05c3b716": persistentvolume deleted
    I1008 18:58:54.159706       1 controller.go:1537] delete "pvc-0e8331f7-de7a-4c0c-a678-724e05c3b716": succeeded
    E1008 18:58:54.159752       1 controller.go:1056] volume "pvc-0e8331f7-de7a-4c0c-a678-724e05c3b716" in work queue no longer exists
```