### PR TITLE
Stop linking to deprecated external-storage and creating infinite loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # sig-storage-lib-external-provisioner
 
-A library for writing [external provisioners](https://kubernetes.io/docs/concepts/storage/storage-classes/#provisioner). See [external-storage](https://github.com/kubernetes-incubator/external-storage) for community-maintained external provisioners that use this library.
+A library for writing [external provisioners](https://kubernetes.io/docs/concepts/storage/storage-classes/#provisioner). Projects using this library include:
+- https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner - Dynamic sub-dir volume provisioner on a remote NFS server.
+- https://github.com/kubernetes-sigs/nfs-ganesha-server-and-external-provisioner - NFS Ganesha Server and Volume Provisioner.
+- https://github.com/kubernetes-csi/external-provisioner - Sidecar container that watches Kubernetes PersistentVolumeClaim objects and triggers CreateVolume/DeleteVolume against a CSI endpoint
 
 ## Packages
 ### `controller`


### PR DESCRIPTION
This fixes https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/issues/85

I took the descriptions from the repos themselves.