### PR TITLE
catch error when adding uid indexer for pvc informer

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -710,13 +710,16 @@ func NewProvisionController(
 		controller.claimInformer = informer.Core().V1().PersistentVolumeClaims().Informer()
 		controller.claimInformer.AddEventHandler(claimHandler)
 	}
-	controller.claimInformer.AddIndexers(cache.Indexers{uidIndex: func(obj interface{}) ([]string, error) {
+	err = controller.claimInformer.AddIndexers(cache.Indexers{uidIndex: func(obj interface{}) ([]string, error) {
 		uid, err := getObjectUID(obj)
 		if err != nil {
 			return nil, err
 		}
 		return []string{uid}, nil
 	}})
+	if err != nil {
+		klog.Fatalf("Error setting indexer %s for pvc informer: %v", uidIndex, err)
+	}
 	controller.claimsIndexer = controller.claimInformer.GetIndexer()
 
 	// -----------------


### PR DESCRIPTION
I got following error when running provisioner, It seems that I start informer before adding uid indexer, It cost me some time to dubug this problem, should we add this check to help find problems ?

`W0111 16:24:40.929792       1 controller.go:886] Retrying syncing claim "33496b4f-53df-11eb-b3b4-525400565f40", failure 14
E0111 16:24:40.929825       1 controller.go:908] error syncing claim "33496b4f-53df-11eb-b3b4-525400565f40": Index with name uid does not exist`