### PR TITLE
controller: always add modified PVCs and PVs

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -798,9 +798,7 @@ func (ctrl *ProvisionController) enqueueClaim(obj interface{}) {
 		utilruntime.HandleError(err)
 		return
 	}
-	if ctrl.claimQueue.NumRequeues(uid) == 0 {
-		ctrl.claimQueue.Add(uid)
-	}
+	ctrl.claimQueue.Add(uid)
 }
 
 // enqueueVolume takes an obj and converts it into a namespace/name string which
@@ -812,11 +810,7 @@ func (ctrl *ProvisionController) enqueueVolume(obj interface{}) {
 		utilruntime.HandleError(err)
 		return
 	}
-	// Re-Adding is harmless but try to add it to the queue only if it is not
-	// already there, because if it is already there we *must* be retrying it
-	if ctrl.volumeQueue.NumRequeues(key) == 0 {
-		ctrl.volumeQueue.Add(key)
-	}
+	ctrl.volumeQueue.Add(key)
 }
 
 // forgetVolume Forgets an obj from the given work queue, telling the queue to


### PR DESCRIPTION
Checking whether an item is already in the queue is potentially
causing updated items to be ignored that need to be handled. This can
happen for a PVC if:
- the PVC was requeued during the first attempt
- it gets processed again in a state where it doesn't need to be
  provisioned (for example, no node selected for late binding)
- a new revision comes in which does need to be provisioned
  but doesn't get added because of the "NumRequeues" check
- the second attempt finishes and removes the PVC from
  the queue