### PR TITLE
Set provision-by anno to the storage class provisioner

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1446,7 +1446,10 @@ func (ctrl *ProvisionController) provisionClaimOperation(ctx context.Context, cl
 		volume.ObjectMeta.Finalizers = append(volume.ObjectMeta.Finalizers, finalizerPV)
 	}
 
-	metav1.SetMetaDataAnnotation(&volume.ObjectMeta, annDynamicallyProvisioned, ctrl.provisionerName)
+	// Set class.Provisioner here so that for non-csi migration case it is the normal provisioner name
+	// but for CSI Migration case, it will be the in-tree provisioner name be set so that rollback
+	// works for in-tree plugin
+	metav1.SetMetaDataAnnotation(&volume.ObjectMeta, annDynamicallyProvisioned, class.Provisioner)
 	if ctrl.kubeVersion.AtLeast(utilversion.MustParseSemantic("v1.6.0")) {
 		volume.Spec.StorageClassName = claimClass
 	} else {

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -147,7 +147,7 @@ func TestController(t *testing.T) {
 			additionalProvisionerNames: []string{"foo.bar/baz", "foo.xyz/baz"},
 			provisioner:                newTestProvisioner(),
 			expectedVolumes: []v1.PersistentVolume{
-				*newProvisionedVolume(newBetaStorageClass("class-1", "csi.com/mock-csi", nil), newClaim("claim-1", "uid-1-1", "class-1", "foo.bar/baz", "", nil)),
+				*newProvisionedVolume(newBetaStorageClass("class-1", "foo.bar/baz", nil), newClaim("claim-1", "uid-1-1", "class-1", "foo.bar/baz", "", nil)),
 			},
 			expectedMetrics: testMetrics{
 				provisioned: counts{


### PR DESCRIPTION
This PR changes the existing behavior of changing PV provisioned-by annotation to storageclass provisioner.

This is to help fix https://github.com/kubernetes-csi/external-provisioner/issues/576

Basically it means for CSI Migration, newly provisioned PV will have "provisioned-by" annotation set to in-tree provisioner name instead of the CSI provisioner.

