### PR TITLE
Migrates leader election to Lease API

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -864,11 +864,11 @@ func (ctrl *ProvisionController) Run(ctx context.Context) {
 	go ctrl.volumeStore.Run(ctx, DefaultThreadiness)
 
 	if ctrl.leaderElection {
-		rl, err := resourcelock.New("endpoints",
+		rl, err := resourcelock.New("leases",
 			ctrl.leaderElectionNamespace,
 			strings.Replace(ctrl.provisionerName, "/", "-", -1),
-			ctrl.client.CoreV1(),
 			nil,
+			ctrl.client.CoordinationV1(),
 			resourcelock.ResourceLockConfig{
 				Identity:      ctrl.id,
 				EventRecorder: ctrl.eventRecorder,


### PR DESCRIPTION
This PR migrates the leader election to the Lease API.

I ran `make test` and got no errors back, I also ran the `tests/e2e/test.sh` script 
and the process completed successfully. I believe this change completes the migration 
to the Lease API but I'm not entirely certain. If someone can verify this and/or provide 
any other feedback I'll greatly appreciate it!

Please see #111 and this ongoing [issue](https://github.com/kubernetes/kubernetes/issues/80289) for more information.

Fixes #111