### PR TITLE
do not delete the pv in the indexer cache store directly

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1528,12 +1528,7 @@ func (ctrl *ProvisionController) deleteVolumeOperation(ctx context.Context, volu
 		}
 	}
 
-	klog.Info(logOperation(operation, "persistentvolume deleted"))
-
-	if err = ctrl.volumes.Delete(volume); err != nil {
-		utilruntime.HandleError(err)
-	}
-	klog.Info(logOperation(operation, "succeeded"))
+	klog.Info(logOperation(operation, "persistentvolume deleted succeeded"))
 	return nil
 }
 


### PR DESCRIPTION
fix pvInformer cannot trigger delete event, The reason is that after the list watch to the delete event, the flector will judge whether the object exists in the cache store before triggering the delta to process the delete event. If it does not exist, it will be ignored directly as follows:

```
func (f *DeltaFIFO) Delete(obj interface{}) (retErr error) {
	defer func() {
		klog.Errorf("delete delta error %v", retErr)
	}()
	id, err := f.KeyOf(obj)
	klog.Infof("start delete %s", id)
	if err != nil {
		return KeyError{obj, err}
	}
	f.lock.Lock()
	defer f.lock.Unlock()
	f.populated = true
	if f.knownObjects == nil {
		if _, exists := f.items[id]; !exists {
			// Presumably, this was deleted when a relist happened.
			// Don't provide a second report of the same deletion.
			return nil
		}
	} else {
		// We only want to skip the "deletion" action if the object doesn't
		// exist in knownObjects and it doesn't have corresponding item in items.
		// Note that even if there is a "deletion" action in items, we can ignore it,
		// because it will be deduped automatically in "queueActionLocked"
		_, exists, err := f.knownObjects.GetByKey(id)
		_, itemsExist := f.items[id]
		if err == nil && !exists && !itemsExist {
			// Presumably, this was deleted when a relist happened.
			// Don't provide a second report of the same deletion.
			return nil
		}
	}
```

Then sharedIndexInformer will also delete the pv from the indexer store

```
func (s *sharedIndexInformer) HandleDeltas(obj interface{}) error {
	s.blockDeltas.Lock()
	defer s.blockDeltas.Unlock()

	// from oldest to newest
	for _, d := range obj.(Deltas) {
		accessor, _ := meta.Accessor(d.Object)
		klog.Infof("HandleDeltas type %s", d.Type, accessor.GetName())
		switch d.Type {
		case Sync, Replaced, Added, Updated:
			s.cacheMutationDetector.AddObject(d.Object)
			if old, exists, err := s.indexer.Get(d.Object); err == nil && exists {
				if err := s.indexer.Update(d.Object); err != nil {
					return err
				}

				isSync := false
				switch {
				case d.Type == Sync:
					// Sync events are only propagated to listeners that requested resync
					isSync = true
				case d.Type == Replaced:
					if accessor, err := meta.Accessor(d.Object); err == nil {
						if oldAccessor, err := meta.Accessor(old); err == nil {
							// Replaced events that didn't change resourceVersion are treated as resync events
							// and only propagated to listeners that requested resync
							isSync = accessor.GetResourceVersion() == oldAccessor.GetResourceVersion()
						}
					}
				}
				s.processor.distribute(updateNotification{oldObj: old, newObj: d.Object}, isSync)
			} else {
				if err := s.indexer.Add(d.Object); err != nil {
					return err
				}
				s.processor.distribute(addNotification{newObj: d.Object}, false)
			}
		case Deleted:
			if err := s.indexer.Delete(d.Object); err != nil {
				return err
			}
			s.processor.distribute(deleteNotification{oldObj: d.Object}, false)
		}
	}
```
