### PR TITLE
Set log level for k8log.Info calls

### DIFF
--- a/controller/volume_store.go
+++ b/controller/volume_store.go
@@ -211,14 +211,14 @@ func (b *backoffStore) StoreVolume(logger klog.Logger, claim *v1.PersistentVolum
 	// Try to create the PV object several times
 	var lastSaveError error
 	err := wait.ExponentialBackoff(*b.backoff, func() (bool, error) {
-		logger.Info("Trying to save persistentvolume", "persistentvolume", volume.Name)
+		logger.V(4).Info("Trying to save persistentvolume", "persistentvolume", volume.Name)
 		var err error
 		if _, err = b.client.CoreV1().PersistentVolumes().Create(context.Background(), volume, metav1.CreateOptions{}); err == nil || apierrs.IsAlreadyExists(err) {
 			// Save succeeded.
 			if err != nil {
-				logger.Info("Persistentvolume already exists, reusing", "persistentvolume", volume.Name)
+				logger.V(2).Info("Persistentvolume already exists, reusing", "persistentvolume", volume.Name)
 			} else {
-				logger.Info("Persistentvolume saved", "persistentvolume", volume.Name)
+				logger.V(4).Info("Persistentvolume saved", "persistentvolume", volume.Name)
 			}
 			return true, nil
 		}
@@ -247,7 +247,7 @@ func (b *backoffStore) StoreVolume(logger klog.Logger, claim *v1.PersistentVolum
 	err = wait.ExponentialBackoff(*b.backoff, func() (bool, error) {
 		if err = b.ctrl.provisioner.Delete(context.Background(), volume); err == nil {
 			// Delete succeeded
-			logger.Info("Cleaning volume succeeded", "volume", volume.Name)
+			logger.V(4).Info("Cleaning volume succeeded", "volume", volume.Name)
 			return true, nil
 		}
 		// Delete failed, try again after a while.


### PR DESCRIPTION
**What**

The MR sets a log level for `k8log.Info` calls in the module. I used a few sources to choose what level to set:

- https://github.com/kubernetes-csi/external-attacher
- https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md#what-method-to-use

It resulted in setting `V(4)` for informational (e.g, `klog.V(4).Info(logOperation(operation, "started"))`) and successful operations (e.g, `klog.V(4).Info(logOperation(operation, "succeeded"))`. For more important but still informational message I choose `V(2)` (e.g, `klog.V(2).Info(logOperation(operation, "volume rescheduled because: %v", err))`)

**Why**

Higher-level packages like `external-provisioner` provides a way to reduce logging by setting a certain log level at start. But majority of log messages of `sig-storage-lib-external-provisioner` are logged always. In some cases, logging everything may result in excessive logging that is hard to look through. An example is `external-provisioner`, which depends on this module. It is deployed on a few nodes of a cluster. When a volume is deleted, all nodes with running `external-provisioner` receive a request to delete the volume. But only one node contains it. So the log is filled with a plenty of messages `deletion of PV started` and `deletion of PV ignored because the node does not contain the volume` from the other nodes. I think, it would be good to have a "switch" to enable/disable certain message via setting log level as it is done in other Kubernetes packages.