### PR TITLE
Allow graceful shutdown of controller by awaiting context

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -859,7 +859,7 @@ func (ctrl *ProvisionController) Run(ctx context.Context) {
 
 		klog.Infof("Started provisioner controller %s!", ctrl.component)
 
-		select {}
+		<-ctx.Done()
 	}
 
 	go ctrl.volumeStore.Run(ctx, DefaultThreadiness)


### PR DESCRIPTION
As requested per #155 .

Awaits the context and provides a graceful shutdown instead of waiting indefinitely.