### PR TITLE
fix: patch in correct context cancellation

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -51,7 +51,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/client-go/util/workqueue"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v9/controller/metrics"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v9/util"
 )
@@ -744,7 +744,7 @@ func NewProvisionController(
 				Duration: controller.createProvisionedPVInterval,
 				Factor:   1, // linear backoff
 				Steps:    controller.createProvisionedPVRetryCount,
-				//Cap:      controller.createProvisionedPVInterval,
+				// Cap:      controller.createProvisionedPVInterval,
 			}
 		}
 		klog.V(2).Infof("Using blocking saving PVs to API server")
@@ -859,7 +859,7 @@ func (ctrl *ProvisionController) Run(ctx context.Context) {
 
 		klog.Infof("Started provisioner controller %s!", ctrl.component)
 
-		select {}
+		<-ctx.Done()
 	}
 
 	go ctrl.volumeStore.Run(ctx, DefaultThreadiness)


### PR DESCRIPTION
> As requested per https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/issues/155 .
Awaits the context and provides a graceful shutdown instead of waiting indefinitely.

Also some minor import cleanup and documentation auto format.

duplicate of https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/pull/156

Co-authored-by: @MatthiasWerning