### PR TITLE
fix flaking test on TestTopologyParams

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ verify: dep
 	PATH=$$(go env GOPATH)/bin:$$PATH repo-infra/verify/verify-boilerplate.sh
 
 test: dep
-	go test ./controller
-	go test ./allocator
+	go test ./controller -v
+	go test ./allocator -v
 
 clean:
 	rm -rf ./test/e2e/kubernetes

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -924,7 +924,7 @@ func TestTopologyParams(t *testing.T) {
 			name: "provision with selected node",
 			objs: []runtime.Object{
 				newNode("node-1"),
-				newStorageClass("class-1", "foo.bar/baz"),
+				newStorageClassWithVolumeBindingMode("class-1", "foo.bar/baz", &modeWait),
 				newClaim("claim-1", "uid-1-1", "class-1", "foo.bar/baz", "", map[string]string{annSelectedNode: "node-1"}),
 			},
 			expectedParams: &provisionParams{
@@ -935,7 +935,11 @@ func TestTopologyParams(t *testing.T) {
 			name: "provision with AllowedTopologies and selected node",
 			objs: []runtime.Object{
 				newNode("node-1"),
-				newStorageClassWithAllowedTopologies("class-1", "foo.bar/baz", dummyAllowedTopology),
+				func() *storage.StorageClass {
+					sc := newStorageClassWithVolumeBindingMode("class-1", "foo.bar/baz", &modeWait)
+					sc.AllowedTopologies = dummyAllowedTopology
+					return sc
+				}(),
 				newClaim("claim-1", "uid-1-1", "class-1", "foo.bar/baz", "", map[string]string{annSelectedNode: "node-1"}),
 			},
 			expectedParams: &provisionParams{
@@ -946,7 +950,7 @@ func TestTopologyParams(t *testing.T) {
 		{
 			name: "provision with selected node, but node does not exist",
 			objs: []runtime.Object{
-				newStorageClass("class-1", "foo.bar/baz"),
+				newStorageClassWithVolumeBindingMode("class-1", "foo.bar/baz", &modeWait),
 				newClaim("claim-1", "uid-1-1", "class-1", "foo.bar/baz", "", map[string]string{annSelectedNode: "node-1"}),
 			},
 			expectedParams: nil,


### PR DESCRIPTION
The referenced sc should have WaitForFirstConsumer VolumeBindingMode when a pvc has annSelectedNode.

```
=== RUN   TestTopologyParams/provision_with_selected_node,_but_node_does_not_exist
W0315 10:28:53.655414   36645 shared_informer.go:587] resyncPeriod 100ms is too small. Changing it to the minimum allowed value of 1s
W0315 10:28:53.655448   36645 shared_informer.go:587] resyncPeriod 100ms is too small. Changing it to the minimum allowed value of 1s
I0315 10:28:53.655487   36645 leaderelection.go:250] attempting to acquire leader lease default/foo.bar-baz...
I0315 10:28:53.655533   36645 leaderelection.go:260] successfully acquired lease default/foo.bar-baz
I0315 10:28:53.655574   36645 controller.go:817] Starting provisioner controller foo.bar/baz_zhanxis-MacBook-Pro.local_e81b310b-c96f-454f-af7b-5a9565ccf74c!
I0315 10:28:53.656156   36645 event.go:298] Event(v1.ObjectReference{Kind:"Lease", Namespace:"default", Name:"foo.bar-baz", UID:"", APIVersion:"coordination.k8s.io/v1", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'LeaderElection' zhanxis-MacBook-Pro.local_e81b310b-c96f-454f-af7b-5a9565ccf74c became leader
I0315 10:28:53.755734   36645 controller.go:866] Started provisioner controller foo.bar/baz_zhanxis-MacBook-Pro.local_e81b310b-c96f-454f-af7b-5a9565ccf74c!
I0315 10:28:53.755802   36645 controller.go:1388] provision "default/claim-1" class "class-1": started
I0315 10:28:53.755889   36645 controller.go:1513] provision "default/claim-1" class "class-1": volume rescheduled because: nodes "node-1" not found
I0315 10:28:53.755930   36645 controller.go:1388] provision "default/claim-1" class "class-1": started
I0315 10:28:53.756072   36645 event.go:298] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"claim-1", UID:"uid-1-1", APIVersion:"v1", ResourceVersion:"0", FieldPath:""}): type: 'Warning' reason: 'ProvisioningFailed' nodes "node-1" not found
I0315 10:28:53.756090   36645 event.go:298] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"claim-1", UID:"uid-1-1", APIVersion:"v1", ResourceVersion:"0", FieldPath:""}): type: 'Normal' reason: 'Provisioning' External provisioner is provisioning volume for claim "default/claim-1"
I0315 10:28:53.805999   36645 controller.go:1471] provision "default/claim-1" class "class-1": volume "pvc-uid-1-1" provisioned
I0315 10:28:53.806057   36645 controller.go:1484] provision "default/claim-1" class "class-1": succeeded
I0315 10:28:53.806084   36645 volume_store.go:212] Trying to save persistentvolume "pvc-uid-1-1"
I0315 10:28:53.806125   36645 volume_store.go:219] persistentvolume "pvc-uid-1-1" saved
I0315 10:28:53.806186   36645 event.go:298] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"default", Name:"claim-1", UID:"uid-1-1", APIVersion:"v1", ResourceVersion:"0", FieldPath:""}): type: 'Normal' reason: 'ProvisioningSucceeded' Successfully provisioned volume pvc-uid-1-1
I0315 10:28:53.854359   36645 controller.go:1388] provision "default/claim-1" class "class-1": started
I0315 10:28:53.854387   36645 controller.go:1397] provision "default/claim-1" class "class-1": persistentvolume "pvc-uid-1-1" already exists, skipping
    controller_test.go:972: did not expect a Provision() call but got at least 1
--- FAIL: TestTopologyParams (1.02s)
    --- PASS: TestTopologyParams/provision_without_topology_information (0.20s)
    --- PASS: TestTopologyParams/provision_with_AllowedTopologies (0.20s)
    --- PASS: TestTopologyParams/provision_with_selected_node (0.20s)
    --- PASS: TestTopologyParams/provision_with_AllowedTopologies_and_selected_node (0.21s)
    --- FAIL: TestTopologyParams/provision_with_selected_node,_but_node_does_not_exist (0.20s)
FAIL
FAIL	sigs.k8s.io/sig-storage-lib-external-provisioner/v10/controller	1.805s
```

With this patch:

```
(⎈|kind-kind:N/A)➜  sig-storage-lib-external-provisioner git:(fix-flaking-test-1) stress -p 10 go test -count=1 -run TestTopologyParams ./controller -v
5s: 0 runs so far, 0 failures
10s: 4 runs so far, 0 failures
15s: 13 runs so far, 0 failures
20s: 22 runs so far, 0 failures
25s: 32 runs so far, 0 failures
30s: 42 runs so far, 0 failures
35s: 53 runs so far, 0 failures
40s: 64 runs so far, 0 failures
45s: 70 runs so far, 0 failures
50s: 79 runs so far, 0 failures
55s: 89 runs so far, 0 failures
1m0s: 98 runs so far, 0 failures
1m5s: 109 runs so far, 0 failures
^C
```

/cc @xing-yang @msau42 @deepakkinni 

Fixes #160