### PR TITLE
Automated cherry pick of #173: Fix removal of PV protection finalizer

### DIFF
--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -1406,12 +1406,21 @@ func TestRemoveFinalizer(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
+			var originalFinalizers []string
+			if test.finalizers != nil {
+				originalFinalizers = make([]string, len(test.finalizers))
+				copy(originalFinalizers, test.finalizers)
+			}
+
 			modifiedFinalizers, modified := removeFinalizer(test.finalizers, test.finalizerToRemove)
 			if test.expectedModified != modified {
 				t.Errorf("expected modified %v but got %v\n", test.expectedModified, modified)
 			}
 			if !reflect.DeepEqual(test.expectedFinalizers, modifiedFinalizers) {
 				t.Errorf("expected finalizers %v but got %v\n", test.expectedFinalizers, modifiedFinalizers)
+			}
+			if !reflect.DeepEqual(test.finalizers, originalFinalizers) {
+				t.Errorf("removeFinalizer() has modified the source finalizers %+v to %+v", originalFinalizers, test.finalizers)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #173 on release-10.0.

#173: Fix removal of PV protection finalizer

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed removal of PV protection finalizer. PVs are no longer Terminating forever after PVC deletion.
```