### PR TITLE
Update the cache through the watch mechanism. Do not update directly.…

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -1516,9 +1516,6 @@ func (ctrl *ProvisionController) provisionClaimOperation(ctx context.Context, cl
 	if err := ctrl.volumeStore.StoreVolume(logger, claim, volume); err != nil {
 		return ProvisioningFinished, err
 	}
-	if err = ctrl.volumes.Add(volume); err != nil {
-		utilruntime.HandleError(err)
-	}
 	return ProvisioningFinished, nil
 }
 


### PR DESCRIPTION
… This will cause abnormal overwriting.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Updating the restore cache here might overwrite the cache observed by reflect watch, leading to incorrect data in the cache, especially the status.phase field. This is because the volume here is merely an object constructed by provision and not the actual object stored in etcd.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fixed overwriting of internal informer cache. This could lead to multiple Provision() calls for a single PVC in very rare (impossible?) cases. The library relies on idempotency of the Provision() call. Please report any frequent duplicate Provision() calls.
```
