### PR TITLE
bugfix: open resync for listeners with internal claim and volume informers in provision controller

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -710,10 +710,12 @@ func NewProvisionController(
 	}
 
 	if controller.claimInformer != nil {
+		// This resyncPeriod may not take effect, due to this external claimInformer may do no resyncs at all.
 		controller.claimInformer.AddEventHandlerWithResyncPeriod(claimHandler, controller.resyncPeriod)
 	} else {
 		controller.claimInformer = informer.Core().V1().PersistentVolumeClaims().Informer()
-		controller.claimInformer.AddEventHandler(claimHandler)
+		// Add resyncPeriod clearly when adding eventHandler to indicate this listener need resync.
+		controller.claimInformer.AddEventHandlerWithResyncPeriod(claimHandler, controller.resyncPeriod)
 	}
 	err = controller.claimInformer.AddIndexers(cache.Indexers{uidIndex: func(obj interface{}) ([]string, error) {
 		uid, err := getObjectUID(obj)
@@ -738,10 +740,11 @@ func NewProvisionController(
 	}
 
 	if controller.volumeInformer != nil {
+		// This resyncPeriod may not take effect, due to this external volumeInformer may do no resyncs at all.
 		controller.volumeInformer.AddEventHandlerWithResyncPeriod(volumeHandler, controller.resyncPeriod)
 	} else {
 		controller.volumeInformer = informer.Core().V1().PersistentVolumes().Informer()
-		controller.volumeInformer.AddEventHandler(volumeHandler)
+		controller.volumeInformer.AddEventHandlerWithResyncPeriod(volumeHandler, controller.resyncPeriod)
 	}
 	controller.volumes = controller.volumeInformer.GetStore()
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
<!-- 
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
-->

**What this PR does / why we need it**:
Currently, the listeners with internal claim and volume informers didn't open resync.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
