### PR TITLE
wip: Update lib module to v11

### DIFF
--- a/allocator/doc.go
+++ b/allocator/doc.go
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package allocator // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v10/allocator"
+package allocator // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v11/allocator"

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -55,8 +55,8 @@ import (
 	ref "k8s.io/client-go/tools/reference"
 	"k8s.io/client-go/util/workqueue"
 	klog "k8s.io/klog/v2"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v10/controller/metrics"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v10/util"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v11/controller/metrics"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v11/util"
 )
 
 // This annotation is added to a PV that has been dynamically provisioned by

--- a/controller/controller_test.go
+++ b/controller/controller_test.go
@@ -46,7 +46,7 @@ import (
 	klog "k8s.io/klog/v2"
 	"k8s.io/klog/v2/ktesting"
 	_ "k8s.io/klog/v2/ktesting/init"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v10/controller/metrics"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v11/controller/metrics"
 )
 
 const (

--- a/controller/doc.go
+++ b/controller/doc.go
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package controller // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v10/controller"
+package controller // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v11/controller"

--- a/controller/metrics/doc.go
+++ b/controller/metrics/doc.go
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package metrics // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v10/controller/metrics"
+package metrics // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v11/controller/metrics"

--- a/examples/hostpath-provisioner/go.mod
+++ b/examples/hostpath-provisioner/go.mod
@@ -9,7 +9,7 @@ require (
 	k8s.io/apimachinery v0.30.0
 	k8s.io/client-go v0.30.0
 	k8s.io/klog/v2 v2.120.1
-	sigs.k8s.io/sig-storage-lib-external-provisioner/v10 v10.0.0-20240423100449-ea3e5f96b47e
+	sigs.k8s.io/sig-storage-lib-external-provisioner/v10 v10.0.1
 )
 
 require (

--- a/examples/hostpath-provisioner/hostpath-provisioner.go
+++ b/examples/hostpath-provisioner/hostpath-provisioner.go
@@ -24,7 +24,7 @@ import (
 	"path"
 	"syscall"
 
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v10/controller"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v11/controller"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/gidallocator/doc.go
+++ b/gidallocator/doc.go
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package gidallocator // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v10/gidallocator"
+package gidallocator // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v11/gidallocator"

--- a/gidallocator/gidallocator.go
+++ b/gidallocator/gidallocator.go
@@ -28,9 +28,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	klog "k8s.io/klog/v2"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v10/allocator"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v10/controller"
-	"sigs.k8s.io/sig-storage-lib-external-provisioner/v10/util"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v11/allocator"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v11/controller"
+	"sigs.k8s.io/sig-storage-lib-external-provisioner/v11/util"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module sigs.k8s.io/sig-storage-lib-external-provisioner/v10
+module sigs.k8s.io/sig-storage-lib-external-provisioner/v11
 
 go 1.22.0
 

--- a/mount/doc.go
+++ b/mount/doc.go
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package mount // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v10/mount"
+package mount // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v11/mount"

--- a/util/doc.go
+++ b/util/doc.go
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package util // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v10/util"
+package util // import "sigs.k8s.io/sig-storage-lib-external-provisioner/v11/util"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug


/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Today module name is still [[sigs.k8s.io/sig-storage-lib-external-provisioner/v10](http://sigs.k8s.io/sig-storage-lib-external-provisioner/v10)](http://sigs.k8s.io/sig-storage-lib-external-provisioner/v10](http://sigs.k8s.io/sig-storage-lib-external-provisioner/v10))

Those that depend on this library cannot upgrade to the v11.0.0 release, because it leads to following error:
❯ go mod tidy
go: errors parsing go.mod:
go.mod:30:2: require sigs.k8s.io/sig-storage-lib-external-provisioner/v10: version "v11.0.0" invalid: should be v10, not v11

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

/hold

I want to test locally with external-provisioner 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Update module name to sigs.k8s.io/sig-storage-lib-external-provisioner/v11
```
