### PR TITLE
Address various linter (staticcheck, modernize, etc.) comments.

### DIFF
--- a/gidallocator/gidallocator.go
+++ b/gidallocator/gidallocator.go
@@ -90,6 +90,9 @@ func (a *Allocator) AllocateNext(logger klog.Logger, options controller.Provisio
 // table.
 func (a *Allocator) Release(logger klog.Logger, volume *v1.PersistentVolume) error {
 	class, err := a.client.StorageV1().StorageClasses().Get(context.Background(), util.GetPersistentVolumeClass(volume), metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
 	gidMin, gidMax, err := parseClassParameters(class.Parameters)
 	if err != nil {
 		return err

--- a/mount/mountinfo_linux.go
+++ b/mount/mountinfo_linux.go
@@ -77,13 +77,13 @@ func parseInfoFile(r io.Reader) ([]*Info, error) {
 		if _, err := fmt.Sscanf(text, mountinfoFormat,
 			&p.ID, &p.Parent, &p.Major, &p.Minor,
 			&p.Root, &p.Mountpoint, &p.Opts, &optionalFields); err != nil {
-			return nil, fmt.Errorf("Scanning '%s' failed: %s", text, err)
+			return nil, fmt.Errorf("scanning '%s' failed: %s", text, err)
 		}
 		// Safe as mountinfo encodes mountpoints with spaces as \040.
 		index := strings.Index(text, " - ")
 		postSeparatorFields := strings.Fields(text[index+3:])
 		if len(postSeparatorFields) < 3 {
-			return nil, fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
+			return nil, fmt.Errorf("found less than 3 fields post '-' in %q", text)
 		}
 
 		if optionalFields != "-" {

--- a/util/util.go
+++ b/util/util.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 
 	"github.com/miekg/dns"
 	v1 "k8s.io/api/core/v1"
@@ -52,12 +53,7 @@ func RoundUpToGiB(sizeBytes int64) int64 {
 
 // AccessModesContains returns whether the requested mode is contained by modes
 func AccessModesContains(modes []v1.PersistentVolumeAccessMode, mode v1.PersistentVolumeAccessMode) bool {
-	for _, m := range modes {
-		if m == mode {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(modes, mode)
 }
 
 // AccessModesContainedInAll returns whether all of the requested modes are contained by modes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:  this PR seeks to update the sig-storage-lib-external-provisioner repo so
various Go linters no longer raise any warnings for the code. The repo should follow modern Go constructs and best
practices.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Action Required: signatures of two functions changed to ask for string-typed rate limiters.
- RateLimiter
- CreateProvisionedPVLimiter
```
