### PR TITLE
Fix `rescheduleProvisioning` to handle concurrent PVC modifications

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -56,6 +56,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	ref "k8s.io/client-go/tools/reference"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	klog "k8s.io/klog/v2"
 	"sigs.k8s.io/sig-storage-lib-external-provisioner/v13/controller/metrics"
@@ -1391,24 +1392,34 @@ func (ctrl *ProvisionController) rescheduleProvisioning(ctx context.Context, cla
 		return nil
 	}
 
-	// The claim from method args can be pointing to watcher cache. We must not
-	// modify these, therefore create a copy.
-	newClaim := claim.DeepCopy()
-	delete(newClaim.Annotations, annSelectedNode)
-	// Try to update the PVC object
-	if _, err := ctrl.client.CoreV1().PersistentVolumeClaims(newClaim.Namespace).Update(ctx, newClaim, metav1.UpdateOptions{}); err != nil {
+	var newClaim *v1.PersistentVolumeClaim
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		freshClaim, err := ctrl.client.CoreV1().PersistentVolumeClaims(claim.Namespace).Get(ctx, claim.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if _, ok := freshClaim.Annotations[annSelectedNode]; !ok {
+			return nil // already removed, nothing to do
+		}
+		delete(freshClaim.Annotations, annSelectedNode)
+		newClaim, err = ctrl.client.CoreV1().PersistentVolumeClaims(freshClaim.Namespace).Update(ctx, freshClaim, metav1.UpdateOptions{})
+		return err
+	})
+	if err != nil {
 		return fmt.Errorf("delete annotation 'annSelectedNode' for PersistentVolumeClaim %q: %v", klog.KObj(newClaim), err)
 	}
 
 	// Save updated claim into informer cache to avoid operations on old claim.
-	if err := ctrl.claimInformer.GetStore().Update(newClaim); err != nil {
-		// This shouldn't happen because it is a local
-		// operation. The only situation in which Update fails
-		// is when the object is invalid, which isn't the case
-		// here
-		// (https://github.com/kubernetes/client-go/blob/eb0bad8167df60e402297b26e2cee1bddffde108/tools/cache/store.go#L154-L162).
-		// Log the error and hope that a regular cache update will resolve it.
-		klog.FromContext(ctx).Info("Update claim informer cache for PersistentVolumeClaim", "PVC", klog.KObj(newClaim), "err", err)
+	if newClaim != nil {
+		if err := ctrl.claimInformer.GetStore().Update(newClaim); err != nil {
+			// This shouldn't happen because it is a local
+			// operation. The only situation in which Update fails
+			// is when the object is invalid, which isn't the case
+			// here
+			// (https://github.com/kubernetes/client-go/blob/eb0bad8167df60e402297b26e2cee1bddffde108/tools/cache/store.go#L154-L162).
+			// Log the error and hope that a regular cache update will resolve it.
+			klog.FromContext(ctx).Info("Update claim informer cache for PersistentVolumeClaim", "PVC", klog.KObj(newClaim), "err", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

[rescheduleProvisioning](https://github.com/kubernetes-sigs/sig-storage-lib-external-provisioner/blob/master/controller/controller.go#L1388) removes the `volume.kubernetes.io/selected-node` annotation from a PVC to trigger rescheduling after a CSI driver returns `ResourceExhausted` error. 

The current code does a deep copy of the claim from the informer cache and then makes an Update call to API server. If any other controller modifies the PVC between the cache read and the update call (e.g. the PV controller adding storage-provisioner annotations, or the PVC protection controller updating conditions), the API server returns a 409 Conflict and the annotation removal is silently abandoned. The provisioner then falls back to retrying with exponential backoff, adding unnecessary cycles - this is why `CSI Mock volume storage capacity storage capacity exhausted, late binding, with topology` flakes, in real environments this resolves itself since the provisioner requeues and eventually the update goes through.

This PR switches to patch operation, which only touches the single annotation and does not depend on resource version making it resilient to concurrent modifications and shaves off unnecessary cycles.

**Which issue(s) this PR fixes**:

kubernetes/kubernetes#138051

Related: kubernetes/kubernetes#138230 (test-side fix)

**Special notes for your reviewer**:

See provisioner sidecar logs from the [flaking test run](https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-kind-alpha-beta-features/2040915441060155392/artifacts/_sig-storage_CSI_Mock_volume_storage_capacity/exhausted_late_binding_with_topology/storage_capacity/exhausted_late_binding_with_topology/csi-mockplugin-0-csi-provisioner.log):
```
controller.go:1598 "Volume rescheduling failed"
    err="delete annotation 'annSelectedNode' for PersistentVolumeClaim
    \"pvc-m9946\": Operation cannot be fulfilled on persistentvolumeclaims
    \"pvc-m9946\": the object has been modified; please apply your changes
    to the latest version and try again"
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
