### PR TITLE
Fix CI by updating logcheck and verify script

### DIFF
--- a/hack/verify-logcheck.sh
+++ b/hack/verify-logcheck.sh
@@ -21,7 +21,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-LOGCHECK_VERSION=${1:-0.8.2}
+LOGCHECK_VERSION=${1:-0.10.1}
 
 # This will canonicalize the path
 SIG_STORAGE_LIB_EXTERNAL_PROVISIONER_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd -P)
@@ -33,5 +33,6 @@ trap 'rm -rf "${SIG_STORAGE_LIB_EXTERNAL_PROVISIONER_TEMP}"' EXIT
 
 echo "Installing logcheck to temp dir: sigs.k8s.io/logtools/logcheck@v${LOGCHECK_VERSION}"
 GOBIN="${SIG_STORAGE_LIB_EXTERNAL_PROVISIONER_TEMP}" go install "sigs.k8s.io/logtools/logcheck@v${LOGCHECK_VERSION}"
-echo "Verifing logcheck: ${SIG_STORAGE_LIB_EXTERNAL_PROVISIONER_TEMP}/logcheck -check-contextual ${SIG_STORAGE_LIB_EXTERNAL_PROVISIONER_ROOT}/..."
-"${SIG_STORAGE_LIB_EXTERNAL_PROVISIONER_TEMP}/logcheck" -check-contextual -check-with-helpers "${SIG_STORAGE_LIB_EXTERNAL_PROVISIONER_ROOT}/..."
+cd "${SIG_STORAGE_LIB_EXTERNAL_PROVISIONER_ROOT}"
+echo "Verifing logcheck: ${SIG_STORAGE_LIB_EXTERNAL_PROVISIONER_TEMP}/logcheck -check-contextual ./..."
+"${SIG_STORAGE_LIB_EXTERNAL_PROVISIONER_TEMP}/logcheck" -check-contextual -check-with-helpers "./..."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

CI

**What this PR does / why we need it**:

This PR fixes the CI `pull-sig-storage-lib-external-provisioner-build` job which runs in this repo. Its currently failing because logcheck v0.8.2 pulls in golang.org/x/tools v0.21.0 which doesn't compile with the current Go toolchain. We bump to v0.10.1 and switch the verify script to use a relative path since newer go/analysis versions don't accept absolute paths.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
